### PR TITLE
collect address from vicinity

### DIFF
--- a/src/bar_finder.js
+++ b/src/bar_finder.js
@@ -25,7 +25,7 @@ class BarFinder {
     return rawResults.map(bar => {
       return {
         name: bar.name,
-        formatted_address: bar.formatted_address,
+        formatted_address: bar.vicinity,
         location: {
           lat: bar.geometry.location.lat,
           lng: bar.geometry.location.lng


### PR DESCRIPTION
This is a bit of a compromise:
as it turns out both formatted_address and vicinity are optional information, so they may not appear.
Vicinity is provided with place type ["establishment"] which hopefully most search results will be.